### PR TITLE
Add 'amount' to TX history related to hashX

### DIFF
--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -75,7 +75,7 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
                 auto & ag = hashXAggregated[ hashX ];
                 ag.outs.emplace_back( outputIdx );
                 if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back().txnum != txIdx)
-                    vec.emplace_back(txIdx);
+                    vec.push_back( { txIdx, bitcoin::Amount::zero() } );
             }
             else {
                 ++nOpReturns;
@@ -160,7 +160,7 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
                 auto & ag = hashXAggregated[ hashX ];
                 ag.ins.emplace_back(inIdx);
                 if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back().txnum != inp.txIdx)
-                    vec.emplace_back(inp.txIdx);  // now that we resolved the input's spending address, mark this input's txIdx as having touched this hashX
+                    vec.push_back( {inp.txIdx, bitcoin::Amount::zero() });  // now that we resolved the input's spending address, mark this input's txIdx as having touched this hashX
             }
         }
         ++inIdx;

--- a/src/BlockProc.cpp
+++ b/src/BlockProc.cpp
@@ -74,7 +74,7 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
                 // add this output to the hashX -> outputs association for later
                 auto & ag = hashXAggregated[ hashX ];
                 ag.outs.emplace_back( outputIdx );
-                if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back() != txIdx)
+                if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back().txnum != txIdx)
                     vec.emplace_back(txIdx);
             }
             else {
@@ -159,7 +159,7 @@ void PreProcessedBlock::fill(BlockHeight blockHeight, size_t blockSize, const bi
                 const HashX hashX = BTC::HashXFromCScript(cscript);
                 auto & ag = hashXAggregated[ hashX ];
                 ag.ins.emplace_back(inIdx);
-                if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back() != inp.txIdx)
+                if (auto & vec = ag.txNumsInvolvingHashX; vec.empty() || vec.back().txnum != inp.txIdx)
                     vec.emplace_back(inp.txIdx);  // now that we resolved the input's spending address, mark this input's txIdx as having touched this hashX
             }
         }

--- a/src/BlockProc.h
+++ b/src/BlockProc.h
@@ -41,6 +41,18 @@ struct PreProcessedBlock;
 using PreProcessedBlockPtr = std::shared_ptr<PreProcessedBlock>;  ///< For clarity/convenience
 
 struct TxNumWithValue {
+            bool operator< (const TxNumWithValue& r) const {
+                return txnum < r.txnum;
+            }
+
+            bool operator< (const TxNum& r) const {
+                return txnum < r;
+            }
+
+            bool operator== (const TxNumWithValue& r) const {
+                return txnum == r.txnum;
+            }
+
             TxNum txnum;
             bitcoin::Amount amount = bitcoin::Amount::zero();
 };

--- a/src/BlockProc.h
+++ b/src/BlockProc.h
@@ -40,6 +40,11 @@
 struct PreProcessedBlock;
 using PreProcessedBlockPtr = std::shared_ptr<PreProcessedBlock>;  ///< For clarity/convenience
 
+struct TxNumWithValue {
+            TxNum txnum;
+            bitcoin::Amount amount = bitcoin::Amount::zero();
+};
+
 /// Note all hashes below are in *reversed* order from bitcoind's internal memory order.
 /// The reason for that is so that we have this PreProcessedBlock ready with the right format for putting into the db
 /// for later serving up to EX clients.
@@ -92,7 +97,7 @@ struct PreProcessedBlock
         /// Tx indices, always sorted. Initially it's just a list of txIdx into the txInfos array but gets transformed
         /// down the block processing pipeline (in addBlock) to be a list of globally-mapped TxNums involving this
         /// HashX.
-        std::vector<TxNum> txNumsInvolvingHashX;
+        std::vector<TxNumWithValue> txNumsInvolvingHashX;
     };
 
     /// Node map preferable here. Even though a flat map uses move construction, it would still have to move ~72

--- a/src/Storage.cpp
+++ b/src/Storage.cpp
@@ -2285,8 +2285,7 @@ void Storage::addBlock(PreProcessedBlockPtr ppb, bool saveUndo, unsigned nReserv
                             info.hashX = hashX;
                             info.amount = out.amount;
 
-                            auto has_hashx = credit_debits.find(hashX);
-                            if (has_hashx != credit_debits.end()) {
+                            if (auto has_hashx = credit_debits.find(hashX); has_hashx != credit_debits.end()) {
                                credit_debits[hashX] += out.amount; 
                             } else {
                                 credit_debits[hashX] = out.amount;

--- a/src/Storage.h
+++ b/src/Storage.h
@@ -215,6 +215,7 @@ public:
     struct HistoryItem {
         TxHash hash;
         int height = 0; ///< block height. 0 = unconfirmed, -1 = unconfirmed with unconfirmed parent. Note this is ambiguous with block 0 :(
+        bitcoin::Amount credit_debit = bitcoin::Amount::zero();
         std::optional<bitcoin::Amount> fee; ///< fee, if known. this is only ever populated with a value for unconfirmed (mempool) tx's
 
         // for sort & maps


### PR DESCRIPTION
Attempting to also track 'amount' in addition to the TXID for each
TX that involves the key (hashX).